### PR TITLE
Ignore private converters by object converter registry

### DIFF
--- a/src/main/java/com/github/vbauer/houdini/service/impl/ObjectConverterRegistryImpl.java
+++ b/src/main/java/com/github/vbauer/houdini/service/impl/ObjectConverterRegistryImpl.java
@@ -9,6 +9,7 @@ import com.github.vbauer.houdini.service.ObjectConverterRegistry;
 import com.github.vbauer.houdini.util.ReflectionUtils;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -70,8 +71,9 @@ public class ObjectConverterRegistryImpl implements ObjectConverterRegistry {
         final boolean isProxyMethod = method.isBridge() || method.isSynthetic();
         final boolean hasAnnotation = method.getAnnotation(ObjectConverter.class) != null
                 || beanClass.getAnnotation(ObjectConverter.class) != null;
+        final boolean isPublic = Modifier.isPublic(method.getModifiers());
 
-        return !isProxyMethod && isDeclaredMethod && hasAnnotation;
+        return !isProxyMethod && isDeclaredMethod && hasAnnotation && isPublic;
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/src/test/java/com/github/vbauer/houdini/converter/UserConverter.java
+++ b/src/test/java/com/github/vbauer/houdini/converter/UserConverter.java
@@ -34,4 +34,8 @@ public class UserConverter {
         throw new UnsupportedOperationException("Converter is not supported");
     }
 
+    private UserDTO privateConverter(final String login) {
+        return shortInfo(new User().setLogin(login));
+    }
+
 }

--- a/src/test/java/com/github/vbauer/houdini/core/BasicIoCTest.java
+++ b/src/test/java/com/github/vbauer/houdini/core/BasicIoCTest.java
@@ -51,6 +51,11 @@ public abstract class BasicIoCTest {
         assertThat(checkUserDTO(userDTO, true), notNullValue());
     }
 
+    @Test(expected = MissedObjectConverterException.class)
+    public void testPrivateConverter() {
+        converterService.convert(UserDTO.class, LOGIN);
+    }
+
     @Test(expected = UnsupportedOperationException.class)
     public void testBadConverter() {
         final User user = createUser();


### PR DESCRIPTION
```ObjectConverterRegistryImpl.registerConverters``` uses ```getDeclaredMethods()``` which retrieves methods of all scopes. The scope is not checked in ```isConverterMethod()```, thus all methods of a class annotated with ```@ObjectConverter``` are added to the registry. So there is a chance to get IllegalStateException or DuplicatedObjectConverterException when private method with appropriate in / out parameters is added to the class.  